### PR TITLE
refactor: move ShiftAppointment interface to a separate type file for…

### DIFF
--- a/frontend/src/components/EmployeeDashboard/ShiftShedule.tsx
+++ b/frontend/src/components/EmployeeDashboard/ShiftShedule.tsx
@@ -2,20 +2,7 @@ import type React from "react"
 import { useEffect, useState } from "react"
 import { Calendar, MapPin, Wrench, AlertCircle, CheckCircle2 } from "lucide-react"
 import shiftSchedulingService from "@/services/shiftSchedulingService"
-
-interface ShiftAppointment {
-  appointmentId: string
-  userName: string
-  vehicle: string
-  appointmentType: string
-  serviceOrModification: string
-  serviceCenter: string
-  appointmentDate: string
-  startTime: string
-  endTime: string
-  status: string
-  description: string
-}
+import type { ShiftAppointment } from "@/types/ShiftScheduling"
 
 const ShiftSchedule: React.FC = () => {
   const [appointments, setAppointments] = useState<ShiftAppointment[]>([])

--- a/frontend/src/types/ShiftScheduling.ts
+++ b/frontend/src/types/ShiftScheduling.ts
@@ -1,0 +1,13 @@
+export interface ShiftAppointment {
+  appointmentId: string
+  userName: string
+  vehicle: string
+  appointmentType: string
+  serviceOrModification: string
+  serviceCenter: string
+  appointmentDate: string
+  startTime: string
+  endTime: string
+  status: string
+  description: string
+}


### PR DESCRIPTION
This pull request refactors how the `ShiftAppointment` type is managed in the codebase for better maintainability and type reuse. The `ShiftAppointment` interface is moved to a centralized types file, and the component now imports the type from there instead of defining it inline.

Type management improvements:

* Moved the `ShiftAppointment` interface definition from `ShiftShedule.tsx` to a new shared types file, `frontend/src/types/ShiftScheduling.ts`, to promote reusability and consistency.
* Updated `ShiftShedule.tsx` to import the `ShiftAppointment` type from the new location instead of defining it locally.… better organization